### PR TITLE
chore: Pin JDK to v15

### DIFF
--- a/di-ipv-orchestrator-stub/Dockerfile
+++ b/di-ipv-orchestrator-stub/Dockerfile
@@ -1,9 +1,9 @@
-FROM gradle:jdk16@sha256:d31e12d105e332ec2ef1f31c20eac6d1467295487ac70e534e3c1d0ae4a0506e AS build
+FROM gradle:jdk15@sha256:ea8494d3eec55ecc7c3c9ff0c1106488711be0256cc022f48d86c31a528cc673 AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle build --no-daemon
 
-FROM openjdk:16-slim@sha256:38f6c41a7f4901b734f4a7cfc0daa6a1995b552d7ec9517496788f6cc8090235
+FROM openjdk:15-slim@sha256:82fc670b1757068d299fb3f860201c5c97625b5ca351f903a6de33857398eb82
 
 ENV PORT 8081
 RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001


### PR DESCRIPTION
Java 16 considers the following warning to be an error:
> An illegal reflective access operation has occurred

This commit pins the version to avoid this error